### PR TITLE
changed filepath vs url detection to make it work with Windows filepaths...

### DIFF
--- a/application/libraries/assetic.php
+++ b/application/libraries/assetic.php
@@ -57,7 +57,7 @@ class CI_Assetic {
 	}
 
 	public function addJs($filename, $group = null) {
-		if(parse_url($filename, PHP_URL_SCHEME) === null && strpos($filename, '//:') !== 0)
+		if(strpos($filename, '://') === false)
 			$asset = new FileAsset($filename);
 		else
 			$asset = new HttpAsset($filename);
@@ -109,7 +109,7 @@ class CI_Assetic {
 
 
 	public function addCss($filename, $group = null) {
-		if(parse_url($filename, PHP_URL_SCHEME) === null && strpos($filename, '//:') !== 0)
+		if(strpos($filename, '://') === false)
 			$asset = new FileAsset($filename);
 		else
 			$asset = new HttpAsset($filename);
@@ -169,7 +169,7 @@ class CI_Assetic {
 				$tag[] = array('url' => false, 'content' => $el->dump());
 			else {
 				$filename = $el->getSourceRoot().'/'.$el->getSourcePath();
-				if(parse_url($filename, PHP_URL_SCHEME) === null && strpos($filename, '//:') !== 0)
+				if(strpos($filename, '://') === false)
 					$filename = base_url($filename);
 				$tag[$filename] = array('url' => true, 'content' => $filename);
 			}


### PR DESCRIPTION
I've encountered a problem with passing file paths to  `addJs()` on Windows platform.

The problem seems to stem from checking for URL schemes via `parse_url` on Windows file paths.

``` php
parse_url($filename, PHP_URL_SCHEME);
```

This will return a non-NULL value if  given Windows path (E.g. "C" when given "C:\foo\bar"). Which in turn causes the type check (`FileAsset` vs `HttpAsset`) to erroneously classify these paths as URLs.

I'm also not sure what type of URLs the  second check `strpos($filename, '//:') !== 0` is supposed to catch. Perhaps a typo in the delimiter (`://` instead)?

In any case , I'm proposing a simplified detection mechanism that works across operating systems - identify URLs by an existence check for the "colon slash slash" separator between the protocol and the domain part of an URL.

Hope this makes sense, please review.

Thank you!
